### PR TITLE
feat: 주문 생성 후 30초 후 상태 AWAITING_ACCEPTANCE 로 변경 기능 구현

### DIFF
--- a/src/main/java/clovar/howkiki/domain/order/service/OrderCreateService.java
+++ b/src/main/java/clovar/howkiki/domain/order/service/OrderCreateService.java
@@ -15,17 +15,22 @@ import clovar.howkiki.domain.store.entity.Store;
 import clovar.howkiki.domain.store.repository.StoreRepository;
 import clovar.howkiki.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static clovar.howkiki.global.exception.ErrorCode.*;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class OrderCreateService {
 
     private final OrderRepository orderRepository;
@@ -40,8 +45,9 @@ public class OrderCreateService {
         validateOrderRequest(requestDto, storeId);
 
         // 해당 가게 찾기
+        String methodUrl = "/stores/"+ storeId +"/stores/"+storeId+"/orders";
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new CustomException(STORE_ID_NOT_FOUND, "/stores/"+storeId+"/orders"));
+                .orElseThrow(() -> new CustomException(STORE_ID_NOT_FOUND, methodUrl));
 
         // requestDto에서 주문한 메뉴 이름과 수량이 담긴 finalOrderDetails
         List<FinalOrderDetailDto> orderDetails = requestDto.getFinalOrderDetails();
@@ -56,13 +62,16 @@ public class OrderCreateService {
                 .isTakeOut(requestDto.getIsTakeOut())
                 .tableNumber(requestDto.getTableNumber())
                 .orderPrice(orderPrice)
-                .status(OrderStatus.NOT_YET_SENT)  // 기본상태 : NOT_YET_SENT // 추후 30초 후 AWAITING_ACCEPTANCE 상태로 바뀌도록 설정
+                .status(OrderStatus.NOT_YET_SENT)  // 기본상태 : NOT_YET_SENT // 30초 후 AWAITING_ACCEPTANCE 상태로 바뀌도록 설정
                 .build();
         // 주문 저장
         Order savedOrder = orderRepository.save(order);
 
         // *Order Detail 객체 생성
         List<OrderDetailDto> savedOrderDetail = createOrderDetail(savedOrder, orderDetails, storeId);
+
+        // 스케줄러 호출 - 상태 AWAITING_ACCEPTANCE로 변경
+        scheduleOrderStatusUpdate(order, methodUrl);
 
         // 응답 dto 생성 및 반환
         return OrderResponseDto.fromWithOrderDetail(savedOrder, savedOrderDetail);
@@ -112,6 +121,24 @@ public class OrderCreateService {
         }
 
         return result;  // 변환된 DTO 리스트 반환
+    }
+
+    // 메서드 호출 후 30초 후 상태변경
+    public void scheduleOrderStatusUpdate(Order order, String methodUrl) {
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1); // 스레드 풀 1개 생성
+
+        // 30초 후 상태 변경 작업 실행
+        scheduler.schedule(() -> {
+            try {
+                order.updateStatus(OrderStatus.AWAITING_ACCEPTANCE);
+                orderRepository.save(order);
+                log.info("orderId: " + order.getOrderId() + " - 상태가 AWAITING_ACCEPTANCE로 변경되었습니다.");
+            } catch (Exception e){
+                throw new CustomException(FAILED_TO_SCHEDULE_ORDER_STATUS, methodUrl);
+            } finally {
+                scheduler.shutdown();  // 작업 완료 후 스레드 풀 종료 - 자원 낭비 방지!
+            }
+        }, 30, TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/clovar/howkiki/global/exception/ErrorCode.java
+++ b/src/main/java/clovar/howkiki/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 
     // Order
     STORE_ID_NOT_FOUND(NOT_FOUND, "해당 Id의 가게를 찾을 수 없습니다."),
+    FAILED_TO_SCHEDULE_ORDER_STATUS(CONFLICT, "일정 시간 후 상태 변경 예약에 문제가 발생했습니다."),
     ORDER_DETAIL_EMPTY(BAD_REQUEST, "주문 항목이 비어있습니다."),
     MENU_NOT_FOUND(NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
     MENU_NOT_FOR_THIS_STORE(BAD_REQUEST, "해당 가게의 메뉴가 아닌 메뉴가 포함되어 있습니다."),


### PR DESCRIPTION
## ✏️ 변경 사항
 - 주문 생성 후 30초 후 상태 AWAITING_ACCEPTANCE 로 변경 기능 구현
 
## 🔢 Issue 번호
 - #28 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵 반영 브랜치
ex) feat/order-> develop

### 📑 테스트 결과
![image](https://github.com/user-attachments/assets/57c7cc24-a16f-4703-bec9-a1c8e251d790)
![image](https://github.com/user-attachments/assets/ad6400f7-de12-41d5-aad0-6f6db9e2dd26)
![image](https://github.com/user-attachments/assets/145e9297-2f53-4f5e-b7d7-764b0b78b90f)

### 📚 ETC
- ScheduledExecutorService 활용
 - 비동기 작업을 일정  시간 후에 수행하도록 하는 스레드 기반 작업 스케줄려
