### PR TITLE
fix: CORS 허용 주소 변경 배포 

### DIFF
--- a/src/main/java/clovar/howkiki/global/config/SecurityConfig.java
+++ b/src/main/java/clovar/howkiki/global/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 "https://localhost:3001/",
                 "https://howkiki.netlify.app",
                 "https://silver-tiramisu-633e4a.netlify.app/",
-                "https://app.netlify.com/sites/kikibot/overview"));  // 프론트 배포 후 주소 추가
+                "https://kikibot.netlify.app/"));  // 프론트 배포 후 주소 추가
 
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## ✏️ 변경 사항
 - CORS 허용 주소 - 프론트 챗봇 페이지 배포 주소 변경