### PR TITLE
fix: 메모리 낭비 방지를 위한 sseEmitter 타임아웃 시간 변경

### DIFF
--- a/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
+++ b/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
@@ -35,15 +35,14 @@ public class SseService {
         }
 
         // emitter 생성
-        SseEmitter sseEmitter = new SseEmitter(60L * 60L * 1000L);  // 1시간 유지
+        SseEmitter sseEmitter = new SseEmitter(3* 60 * 1000L);  // 3분간 서버에서 아무것도 보내지 않으면 타임아웃되도록 설정
         emitters.put(sessionToken, sseEmitter);
 
-        // 연결 지속을 위한 ping 보내기
+        // 연결 지속을 위한 ping 보내기 (30초마다)
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         scheduler.scheduleAtFixedRate(() -> {
             try {
                 sseEmitter.send(SseEmitter.event().name("ping").data("연결 중단 방지용 ping"));
-                log.debug("💓 ping sent to sessionToken: {}", sessionToken);
             } catch (IOException e) {
                 log.warn("❌ ping failed - sessionToken: {}", sessionToken);
                 emitters.remove(sessionToken);


### PR DESCRIPTION
## ✏️ 변경 사항
 - ping 보내기 추가 이후 메모리 낭비 방지를 위한 sseEmitter 타임아웃 시간 변경
 - 이전에는 ping이 없어 타임아웃 시간을 길게 설정했지만, 이제 ping을 30초마다 보내므로 짧게 설정해 메모리 낭비 방지
 
## 🔢 Issue 번호
 - #68 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ]코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵 반영 브랜치
ex) feat/notification-> develop

### 📑 테스트 결과

### 📚 ETC
- 
