### PR TITLE
fix: ping이 안오더라도 경고 로그만 찍히고, emiiter 삭제는 타임아웃시에만 하도록 수정

### DIFF
--- a/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
+++ b/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
@@ -45,9 +45,6 @@ public class SseService {
                 sseEmitter.send(SseEmitter.event().name("ping").data("연결 중단 방지용 ping"));
             } catch (IOException e) {
                 log.warn("❌ ping failed - sessionToken: {}", sessionToken);
-                emitters.remove(sessionToken);
-                sseEmitter.complete();
-                scheduler.shutdown();  // 더 이상 heartbeat 안 보내도록 종료
             }
         }, 30, 30, TimeUnit.SECONDS); // 30초마다
 


### PR DESCRIPTION
## ✏️ 변경 사항
 - ping이 안오더라도 경고 로그만 찍히고, emiiter 삭제는 타임아웃시에만 하도록 수정
 
## 🔢 Issue 번호
 - #68 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵 반영 브랜치
ex) feat/notification-> develop

### 📑 테스트 결과

### 📚 ETC
- 
