### PR TITLE
fix: 한 번 알림 전송된 후에 emitter 삭제되어 다시 알림 전송안되는 문제 원인 코드 주석 처리

### DIFF
--- a/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
+++ b/src/main/java/clovar/howkiki/domain/notification/service/SseService.java
@@ -48,11 +48,12 @@ public class SseService {
             }
         }, 30, 30, TimeUnit.SECONDS); // 30초마다
 
-        // 사용자에게 모든 데이터 전송되었다면 emitter 삭제
-        sseEmitter.onCompletion(() -> {
-            log.info("emitter 삭제: SSE Emitter 정상 종료 - sessionToken: {}", sessionToken);
-            emitters.remove(sessionToken);
-        });
+        // 한 번 요청이 들어온 후 아래의 로직 떄문에 더이상 알림이 안오는 문제 발생, 잠시 주석 처리
+//        // 사용자에게 모든 데이터 전송되었다면 emitter 삭제
+//        sseEmitter.onCompletion(() -> {
+//            log.info("emitter 삭제: SSE Emitter 정상 종료 - sessionToken: {}", sessionToken);
+//            emitters.remove(sessionToken);
+//        });
         // emitter의 유효시간 만료시 emmitter 삭제
         sseEmitter.onTimeout(() -> {
             log.info("emitter 삭제: SSE Emitter 타임아웃 - sessionToken: {}", sessionToken);


### PR DESCRIPTION
## ✏️ 변경 사항
 - 한 번 알림 전송된 후에 emitter 삭제되어 다시 알림 전송안되는 문제 원인 코드 주석 처리
 
## 🔢 Issue 번호
 - #68 

## 🔎 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 🪵 반영 브랜치
ex) feat/notification-> develop

### 📑 테스트 결과

### 📚 ETC
- 
